### PR TITLE
Update SeedMake to add support for new config('seeders.dir') format

### DIFF
--- a/src/LaravelSeeder/Command/SeedMake.php
+++ b/src/LaravelSeeder/Command/SeedMake.php
@@ -90,10 +90,15 @@ class SeedMake extends MigrateMakeCommand
     protected function getOutputPath(string $env)
     {
         $targetPath = $this->input->getOption('path');
-
-        $path = (empty($targetPath))
-            ? database_path(config('seeders.dir'))
-            : $this->laravel->basePath() . DIRECTORY_SEPARATOR . $targetPath;
+        $path = database_path() . DIRECTORY_SEPARATOR . 'seeders';
+        
+        if(!empty($targetPath)) {
+            $path = $this->laravel->basePath() . DIRECTORY_SEPARATOR . $targetPath;
+        } else {
+            $pathsFromConfig = config('seeders.dir');
+            if(count($pathsFromConfig))
+                $path = $pathsFromConfig[0];
+        }
 
         return $path . DIRECTORY_SEPARATOR . $env;
     }


### PR DESCRIPTION
The config('seeders.dir') format was previously changed to be an array of paths rather than a single path. However SeedMake wasn't updated to take this into account. Also another change was made which expects the paths in the config to already have database_path(), therefore SeedMake will no longer add this.